### PR TITLE
Add Angular Cameroon Hacktoberfest Collaboration Day Event

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -30,5 +30,13 @@
     "location": "Douala",
     "organizer": "Django Cameroon",
     "registration_url": "https://www.django-cmr.org/djangocon-2025"
-  }
+  },
+  {
+    "title": "Angular Cameroon Hacktoberfest Collaboration Day",
+    "description": "Join Angular Cameroon and Django Cameroon for a day of cross-community collaboration! Contribute to open-source projects, attend lightning talks, and learn from experienced mentors.",
+    "event_date": "2025-10-20",
+    "location": "Bamenda Tech Hub",
+    "organizer": "Angular Cameroon x Django Cameroon",
+    "registration_url": "https://lu.ma/14ixmc37"
+  }  
 ]

--- a/events/templates/events/home.html
+++ b/events/templates/events/home.html
@@ -42,7 +42,7 @@
         Eventator keeps our community inspired.
       </h1>
       <p class="mx-auto mt-6 max-w-2xl text-lg text-slate-200">
-        Browse upcoming gatherings, coding nights, and contribution sprints. Submit your idea and let's grow the Django
+        Browse upcoming events, coding nights, and contribution sprints. Submit your idea and let's grow the Django
         Cameroon footprint during Hacktoberfest 2025.
       </p>
       <div class="mt-10 flex flex-wrap items-center justify-center gap-4 text-sm text-indigo-200">


### PR DESCRIPTION

## Summary

- Added a new Hacktoberfest 2025 event: Angular Cameroon Hacktoberfest Collaboration Day.
- Updated event page wording for improved clarity and readability.
- Seeded JSON data in data/events.json to include the new event.
- Enhances visibility for cross-community collaboration and Hacktoberfest participation.

## Related Issues

Closes #N/A (no specific issue; contribution for Hacktoberfest 2025 event listing)

## Testing

List commands or steps used to verify the change.
- [X] `uv run python manage.py test`
- [X] `uv run python manage.py check`
- [ ] Other: 

## Screenshots

<img width="1440" height="632" alt="Screen Shot 2025-10-03 at 11 38 12" src="https://github.com/user-attachments/assets/5917ad17-167b-4093-84e7-bf12f6706a6a" />


## Checklist

- [X] Added or updated documentation when needed
- [X] Included database migrations or seed updates when required
- [X] Confirmed the description explains any follow-up work left out of this PR
