### PR TITLE
Add DevFest Bamenda 2025 event.

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -30,7 +30,8 @@
     "location": "Virtual",
     "organizer": "Hacktoberfest",
     "registration_url": "https://www.digitalocean.com/community/events/os-hackathon"
-  }
+  },
+  {
     "title": "DjangoCon Cameroon 2025",
     "description": "The annual DjangoCon Cameroon conference, featuring talks, workshops, and networking opportunities for Django enthusiasts.",
     "event_date": "2025-11-15",
@@ -45,5 +46,13 @@
     "location": "Bamenda Tech Hub",
     "organizer": "Angular Cameroon x Django Cameroon",
     "registration_url": "https://lu.ma/14ixmc37"
-  }  
+  },
+  {
+    "title": "DevFest Bamenda 2025",
+    "description": "DevFest Bamenda is GDG Bamenda’s biggest annual tech event, part of the global Google Developer Groups festival. It brings together developers, entrepreneurs, and tech enthusiasts for two days of talks, workshops, code labs, and networking. The 2025 theme is “Building Safe, Secure and Scalable Solutions with AI and Cloud.”",
+    "event_date": "2025-11-28",
+    "location": "Epic Events Center, Bamenda, Cameroon",
+    "organizer": "Google Developer Group (GDG) Bamenda",
+    "registration_url": "https://bit.ly/devfest-bamenda2025"
+  }
 ]


### PR DESCRIPTION
## Summary

- Added an upcoming community event: DevFest Bamenda 2025 to data/events.json

- Event info includes verified date, location, description, and registration link

- Helps keep the community event list up-to-date and relevant for Cameroonian developers

## Related Issues

No related issues.

## Testing

List commands or steps used to verify the change.
- [x] `uv run python manage.py seed_events` (verified event loads correctly)
- [x] Manually checked event displays in event list on local server
- [x] `uv run python manage.py test` (all tests pass)
- [x] Other: Visually confirmed event appears on the homepage

## Screenshots

Attach only if the change alters the UI.

## Checklist

- [x] Added or updated documentation when needed
- [x] Included database migrations or seed updates when required
- [x] Confirmed the description explains any follow-up work left out of this PR
