### PR TITLE
Enhance event description UI with Show more / Show less functionality

### DIFF
--- a/events/templates/events/base.html
+++ b/events/templates/events/base.html
@@ -22,6 +22,8 @@
   </main>
 
   {% include 'events/includes/footer.html' %}
+
+<script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 </body>
 
 </html>

--- a/events/templates/events/home.html
+++ b/events/templates/events/home.html
@@ -87,9 +87,21 @@
             </div>
           </div>
 
-          <p class="my-3 line-clamp-4 text-sm text-slate-200/80 text-overflow-ellipsis">
-            {{ event.description }}
-          </p>
+          <div x-data="{ showFull: false }" class="my-3 text-sm text-slate-200/80">
+            <p :class="showFull ? '' : 'line-clamp-4 text-overflow-ellipsis'">
+              {{ event.description }}
+            </p>
+            {% if event.description|length > 160 %}
+              <button
+                type="button"
+                @click="showFull = !showFull"
+                class="mt-2 text-xs text-indigo-300 underline decoration-dotted underline-offset-4 hover:text-indigo-100 transition-all"
+              >
+                <span x-show="!showFull">Show more</span>
+                <span x-show="showFull">Show less</span>
+              </button>
+            {% endif %}
+          </div>
           <hr class="border-t border-white/10" />
           <dl class="mt-4 space-y-2 text-xs text-indigo-100/80">
             <div class="flex items-start justify-between gap-3">


### PR DESCRIPTION
## Summary

- Improved the event description display on the home page with dynamic "Show more / Show less" functionality

- Long event descriptions are now truncated by default, making the UI cleaner

- Users can view the full description with a single click and collapse it when finished

## Related Issues

No related issues.

## Testing

List commands or steps used to verify the change.
- [x] Manually verified that event descriptions longer than 120 characters show "Show more" and toggle to full/short display
- [x] Confirmed UI responsiveness and styling
- [x] `uv run python manage.py test`
- [ ] Other: 

## Screenshots
part of content hidden
<img width="1435" height="777" alt="image" src="https://github.com/user-attachments/assets/8ca11875-0eee-453d-9ea9-4fa78dba45ac" />

hidden content displayed
<img width="1435" height="777" alt="image" src="https://github.com/user-attachments/assets/a8e97e2a-0042-44b2-94f7-3eccfd025ed9" />


## Checklist

- [x] Added or updated documentation when needed
- [x] Included database migrations or seed updates when required
- [x] Confirmed the description explains any follow-up work left out of this PR
